### PR TITLE
fix a bug that cmake creates a duplicate symbol _main

### DIFF
--- a/HW1-Custom_Vector/CMakeLists.txt
+++ b/HW1-Custom_Vector/CMakeLists.txt
@@ -5,8 +5,8 @@ project(RoboWalker-Vision2022_HW_1)  # project的名字
 set(CMAKE_CXX_STANDARD 20)
 
 # 查找后缀为.cpp的源文件，并打印出来找到的内容
-FILE(GLOB_RECURSE SOURCE "src/*.cpp" )
-message(STATUS "Source files: ${SOURCE}")
+# FILE(GLOB_RECURSE SOURCE "src/*.cpp" )
+# message(STATUS "Source files: ${SOURCE}")
 
 # 增加可执行文件（.cpp文件）
-add_executable(${PROJECT_NAME} ${SOURCE})
+add_executable(${PROJECT_NAME} src/main.cpp src/MyVec.cpp)


### PR DESCRIPTION
Using the original `CMakeLists.txt` file and executing `make` command gives the following error:
```
duplicate symbol '_main' in:
    CMakeFiles/RoboWalker-Vision2022_HW_1.dir/CMakeFiles/3.21.2/CompilerIdCXX/CMakeCXXCompilerId.cpp.o
    CMakeFiles/RoboWalker-Vision2022_HW_1.dir/main.cpp.o
ld: 1 duplicate symbol for architecture x86_64
clang: error: linker command failed with exit code 1 (use -v to see invocation)
make[2]: *** [RoboWalker-Vision2022_HW_1] Error 1
make[1]: *** [CMakeFiles/RoboWalker-Vision2022_HW_1.dir/all] Error 2
make: *** [all] Error 2
```
I referenced this answer and fix it:
https://stackoverflow.com/questions/41205192/1-duplicate-symbol-for-architecture-x86-64-with-cmake

It should be noted that I'm not familiar with `cmake`, so I'm not sure what's causing this problem. And I hope the above reference can help you.